### PR TITLE
Fix uploading Android releases to the Play Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,11 @@ jobs:
     name: Build Android
     runs-on: ubuntu-latest-android-builder
     needs: quality
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
 
     steps:
       - name: Checkout repository
@@ -210,8 +215,26 @@ jobs:
       - name: Generate native iOS/Android projects
         run: npm run prebuild
 
+      - name: Decode upload keystore
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload.jks
+
+      - name: Configure release signing
+        run: |
+          python3 ./scripts/ci/configure-android-signing.py
+          echo "--- Signing config in build.gradle ---"
+          grep -A5 'signingConfigs' android/app/build.gradle | head -25
+
       - name: Tune Gradle for CI runner
         run: |
+          cat >> android/gradle.properties <<EOF
+
+          # Upload keystore credentials
+          UPLOAD_STORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD
+          UPLOAD_KEY_ALIAS=$ANDROID_KEY_ALIAS
+          UPLOAD_KEY_PASSWORD=$ANDROID_KEY_PASSWORD
+          EOF
+
           cat >> android/gradle.properties <<'EOF'
 
           # CI overrides for 8-core / 32GB runner

--- a/scripts/ci/configure-android-signing.py
+++ b/scripts/ci/configure-android-signing.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Patch the Expo-generated build.gradle to use the upload keystore for release signing."""
+
+path = "android/app/build.gradle"
+with open(path) as f:
+    content = f.read()
+
+# Add release signing config after the debug block
+release_config = """
+        release {
+            storeFile file("upload.jks")
+            storePassword findProperty("UPLOAD_STORE_PASSWORD") ?: ""
+            keyAlias findProperty("UPLOAD_KEY_ALIAS") ?: ""
+            keyPassword findProperty("UPLOAD_KEY_PASSWORD") ?: ""
+        }"""
+
+content = content.replace(
+    "storePassword 'android'\n            keyAlias 'androiddebugkey'\n            keyPassword 'android'\n        }\n    }",
+    "storePassword 'android'\n            keyAlias 'androiddebugkey'\n            keyPassword 'android'\n        }"
+    + release_config
+    + "\n    }",
+)
+
+# Use release signing config for release builds
+content = content.replace(
+    "release {\n            // Caution! In production, you need to generate your own keystore file.\n            // see https://reactnative.dev/docs/signed-apk-android.\n            signingConfig signingConfigs.debug",
+    "release {\n            signingConfig signingConfigs.release",
+)
+
+with open(path, "w") as f:
+    f.write(content)
+
+print("Patched build.gradle for release signing")


### PR DESCRIPTION
Fixes #20 

I've generated a new Android upload keystore and requested that I replace it in Google Play Console. It won't be ready until `Mar 8, 2026, 5:46:39 PM UTC`, so we can't make a release until then.