### PR TITLE
Rename Cancel to Stop Now

### DIFF
--- a/app/account/components/DeleteAutomationModal.tsx
+++ b/app/account/components/DeleteAutomationModal.tsx
@@ -92,7 +92,12 @@ export function DeleteAutomationModal({
   const isRunningRef = useRef(false);
 
   const handleClose = useCallback(() => {
-    onClose(latestJobsRef.current);
+    const jobs = latestJobsRef.current.map((job) =>
+      job.status === "running" || job.status === "pending"
+        ? { ...job, status: "canceled" as const }
+        : job,
+    );
+    onClose(jobs);
   }, [onClose]);
 
   const handleRestart = useMemo(

--- a/app/account/components/FinishedModal.tsx
+++ b/app/account/components/FinishedModal.tsx
@@ -2,12 +2,12 @@ import { useModalBottomPadding } from "@/hooks/use-modal-bottom-padding";
 import { MaterialIcons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
 import {
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
+    Modal,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View,
 } from "react-native";
 
 import type { BlueskyJobRecord } from "@/controllers/bluesky/job-types";
@@ -61,6 +61,7 @@ function statusIcon(
   if (status === "completed") return "check-circle";
   if (status === "failed") return "error-outline";
   if (status === "running") return "play-circle";
+  if (status === "canceled") return "cancel";
   return "schedule";
 }
 
@@ -71,6 +72,7 @@ function statusColor(
   if (status === "failed") return palette.warning ?? palette.tint;
   if (status === "completed") return palette.tint;
   if (status === "running") return palette.tint;
+  if (status === "canceled") return palette.icon;
   return palette.icon;
 }
 
@@ -287,9 +289,11 @@ export function FinishedModal({
                   : ""
                 : job.status === "failed"
                   ? " – Failed"
-                  : job.status === "running"
-                    ? " – In progress"
-                    : " – Pending";
+                  : job.status === "canceled"
+                    ? " \u2013 Canceled"
+                    : job.status === "running"
+                      ? " \u2013 In progress"
+                      : " \u2013 Pending";
             return (
               <View key={job.id} style={styles.jobRow}>
                 <MaterialIcons

--- a/app/account/components/SaveAutomationModal.tsx
+++ b/app/account/components/SaveAutomationModal.tsx
@@ -1,34 +1,34 @@
 import { useKeepAwake } from "expo-keep-awake";
 import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
 } from "react";
 import { Modal, ScrollView, Text, View } from "react-native";
 
 import {
-  ButtonRow,
-  ErrorCard,
-  InfoBar,
-  StepRow,
-  SuccessCard,
-  styles,
-  type AutomationModalState,
+    ButtonRow,
+    ErrorCard,
+    InfoBar,
+    StepRow,
+    SuccessCard,
+    styles,
+    type AutomationModalState,
 } from "@/components/account/AutomationModalShared";
 import { ConversationPreview } from "@/components/ConversationPreview";
 import { SpeechBubble } from "@/components/cyd/SpeechBubble";
 import { MessagePreview } from "@/components/MessagePreview";
 import { PostPreview } from "@/components/PostPreview";
 import {
-  getBlueskyController,
-  type BlueskyAccountController,
+    getBlueskyController,
+    type BlueskyAccountController,
 } from "@/controllers";
 import type {
-  BlueskyJobRecord,
-  BlueskyJobRunUpdate,
-  SaveJobOptions,
+    BlueskyJobRecord,
+    BlueskyJobRunUpdate,
+    SaveJobOptions,
 } from "@/controllers/bluesky/job-types";
 import type { PostPreviewData, PreviewData } from "@/controllers/bluesky/types";
 import { useModalBottomPadding } from "@/hooks/use-modal-bottom-padding";
@@ -83,7 +83,12 @@ export function SaveAutomationModal({
   const isRunningRef = useRef(false);
 
   const handleClose = useCallback(() => {
-    onClose(latestJobsRef.current);
+    const jobs = latestJobsRef.current.map((job) =>
+      job.status === "running" || job.status === "pending"
+        ? { ...job, status: "canceled" as const }
+        : job,
+    );
+    onClose(jobs);
   }, [onClose]);
 
   const handleRestart = useMemo(

--- a/app/account/components/__tests__/AutomationModalShared.test.tsx
+++ b/app/account/components/__tests__/AutomationModalShared.test.tsx
@@ -9,15 +9,15 @@ import { Colors } from "@/constants/theme";
 import type { AccountTabPalette } from "@/types/account-tabs";
 
 import {
-  ButtonRow,
-  DangerButton,
-  ErrorCard,
-  getStatusColor,
-  getStatusIcon,
-  InfoBar,
-  SecondaryButton,
-  StepRow,
-  SuccessCard,
+    ButtonRow,
+    DangerButton,
+    ErrorCard,
+    getStatusColor,
+    getStatusIcon,
+    InfoBar,
+    SecondaryButton,
+    StepRow,
+    SuccessCard,
 } from "@/components/account/AutomationModalShared";
 
 const defaultPalette: AccountTabPalette = Colors.light;
@@ -265,7 +265,7 @@ describe("AutomationModalShared", () => {
       );
 
       expect(screen.getByText("Pause")).toBeTruthy();
-      expect(screen.getByText("Cancel")).toBeTruthy();
+      expect(screen.getByText("Stop Now")).toBeTruthy();
     });
 
     it("should render resume button when paused", () => {

--- a/components/account/AutomationModalShared.tsx
+++ b/components/account/AutomationModalShared.tsx
@@ -31,10 +31,11 @@ export type AutomationModalBaseProps = {
  */
 export function getStatusIcon(
   status: BlueskyJobRecord["status"],
-): "check-circle" | "play-circle" | "error-outline" | "schedule" {
+): "check-circle" | "play-circle" | "error-outline" | "schedule" | "cancel" {
   if (status === "completed") return "check-circle";
   if (status === "running") return "play-circle";
   if (status === "failed") return "error-outline";
+  if (status === "canceled") return "cancel";
   return "schedule";
 }
 
@@ -48,6 +49,7 @@ export function getStatusColor(
   if (status === "failed") return palette.warning ?? palette.tint;
   if (status === "completed") return palette.tint;
   if (status === "running") return palette.tint;
+  if (status === "canceled") return palette.icon;
   return palette.icon;
 }
 

--- a/controllers/bluesky/job-types.ts
+++ b/controllers/bluesky/job-types.ts
@@ -22,7 +22,12 @@ export type BlueskyJobType =
   | "deleteMessages"
   | "unfollowUsers";
 
-export type BlueskyJobStatus = "pending" | "running" | "completed" | "failed";
+export type BlueskyJobStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "canceled";
 
 export type BlueskyJobRecord = {
   id: number;


### PR DESCRIPTION
Fixed #43

In automation modals, this renames the "Cancel" button to "Stop Now". Also, when you stop an automation, it sets all of the jobs to have the status "canceled".